### PR TITLE
add swagger docs and swagger plugin

### DIFF
--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -3,6 +3,7 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
+    "plugins": ["@nestjs/swagger"],
     "deleteOutDir": true
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "@nestjs/mapped-types": "^2.0.2",
     "@nestjs/passport": "^10.0.0",
     "@nestjs/platform-express": "^10.1.2",
+    "@nestjs/swagger": "^7.1.8",
     "@nestjs/typeorm": "^10.0.0",
     "@types/express-session": "^1.17.7",
     "@types/passport": "^1.0.12",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   '@nestjs/platform-express':
     specifier: ^10.1.2
     version: 10.1.2(@nestjs/common@10.1.2)(@nestjs/core@10.1.2)
+  '@nestjs/swagger':
+    specifier: ^7.1.8
+    version: 7.1.8(@nestjs/common@10.1.2)(@nestjs/core@10.1.2)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)
   '@nestjs/typeorm':
     specifier: ^10.0.0
     version: 10.0.0(@nestjs/common@10.1.2)(@nestjs/core@10.1.2)(reflect-metadata@0.1.13)(rxjs@7.8.1)(typeorm@0.3.17)
@@ -1094,6 +1097,35 @@ packages:
       - chokidar
     dev: true
 
+  /@nestjs/swagger@7.1.8(@nestjs/common@10.1.2)(@nestjs/core@10.1.2)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13):
+    resolution: {integrity: sha512-Jpl3laGAqvyWccc3auLU0mMjl5hJ2kqzzDb63ynJi5NMbFlgBwrR8FCGBVstSsqL9YSJWLR4L1BZzVmVExcY+g==}
+    peerDependencies:
+      '@fastify/static': ^6.0.0
+      '@nestjs/common': ^9.0.0 || ^10.0.0
+      '@nestjs/core': ^9.0.0 || ^10.0.0
+      class-transformer: '*'
+      class-validator: '*'
+      reflect-metadata: ^0.1.12
+    peerDependenciesMeta:
+      '@fastify/static':
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+    dependencies:
+      '@nestjs/common': 10.1.2(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/core': 10.1.2(@nestjs/common@10.1.2)(@nestjs/platform-express@10.1.2)(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/mapped-types': 2.0.2(@nestjs/common@10.1.2)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)
+      class-transformer: 0.5.1
+      class-validator: 0.14.0
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      path-to-regexp: 3.2.0
+      reflect-metadata: 0.1.13
+      swagger-ui-dist: 5.3.1
+    dev: false
+
   /@nestjs/testing@10.1.2(@nestjs/common@10.1.2)(@nestjs/core@10.1.2)(@nestjs/platform-express@10.1.2):
     resolution: {integrity: sha512-047SBcHxHNj/u/YEBTShaM3ijqjp+I8gbBy/sO18tGI0lHBdQztC6zLfIHddrF3rS2/fBLkES+/kemhkVlkpwQ==}
     peerDependencies:
@@ -1849,7 +1881,6 @@ packages:
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-    dev: true
 
   /array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
@@ -3998,7 +4029,6 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
-    dev: true
 
   /jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -5421,6 +5451,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
     dev: true
+
+  /swagger-ui-dist@5.3.1:
+    resolution: {integrity: sha512-El78OvXp9zMasfPrshtkW1CRx8AugAKoZuGGOTW+8llJzOV1RtDJYqQRz/6+2OakjeWWnZuRlN2Qj1Y0ilux3w==}
+    dev: false
 
   /symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}

--- a/backend/src/core/entities/user.entity.ts
+++ b/backend/src/core/entities/user.entity.ts
@@ -7,6 +7,7 @@ import {
   OneToMany,
 } from 'typeorm';
 import { FriendRequest } from './friend_request.entity'
+import { ApiHideProperty } from '@nestjs/swagger';
 
 @Entity({ name: 'users' })
 export class User {
@@ -16,6 +17,7 @@ export class User {
   @Column()
   login: string;
 
+  @ApiHideProperty()
   @ManyToMany(() => User)
   @JoinTable({
     name: 'friends',
@@ -28,9 +30,11 @@ export class User {
   })
   friends: User[];
 
+  @ApiHideProperty()
   @OneToMany(() => FriendRequest, (friend_request) => friend_request.receiver)
   friend_requests_received: FriendRequest[];
 
+  @ApiHideProperty()
   @OneToMany(() => FriendRequest, (friend_request) => friend_request.sender)
   friend_requests_sent: FriendRequest[];
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,9 +6,15 @@ import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 import { AxiosExceptionFilter } from './filters/axios-exception-filter';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // Swagger
+  const config = new DocumentBuilder().setTitle('API Docs').build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('docs', app, document);
 
   app.use(
     session({

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -21,10 +21,10 @@ export class UsersService {
     return await this.userRepository.findOneBy({ id });
   }
 
-  async getUserFriends(id: number): Promise<User> {
-    return await this.userRepository.findOne({
-      where: { id },
-      relations: { friends: true },
+  async getUserFriends(id: number): Promise<User[]> {
+    const user = await this.getUserById(id);
+    return await this.userRepository.find({
+      where: { friends: user },
     });
   }
 }


### PR DESCRIPTION
Add Swagger API documentation at `/docs` 
![image](https://github.com/tenis-de-mesa/ft_transcendence/assets/26127185/ad82306a-e5e3-4643-9ffd-d4a9780fd8b1)
I enabled the plugin that shows everything on the swagger docs by default: 
https://docs.nestjs.com/openapi/cli-plugin
So if we don't want to show something we need to add this annotation: 
```ts
@ApiHideProperty()
```
I added this property on the User relations to keep the examples less verbose 