### PR TITLE
feat: deleted user messages

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,8 +20,8 @@
     "test:watch": "jest --watchAll",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "NODE_ENV=test jest --bail --runInBand --detectOpenHandles --config ./test/jest-e2e.json",
-    "test:e2e:ci": "NODE_ENV=ci jest --runInBand --bail --detectOpenHandles --config ./test/jest-e2e.json",
+    "test:e2e": "NODE_ENV=test jest --bail --runInBand --config ./test/jest-e2e.json",
+    "test:e2e:ci": "NODE_ENV=ci jest --runInBand --bail --config ./test/jest-e2e.json",
     "typeorm": "typeorm-ts-node-commonjs",
     "migration:show": "typeorm-ts-node-commonjs migration:show -d src/data-source.ts",
     "migration:run": "typeorm-ts-node-commonjs migration:run -d src/data-source.ts"

--- a/backend/src/chats/chats.service.ts
+++ b/backend/src/chats/chats.service.ts
@@ -130,7 +130,7 @@ export class ChatsService {
       where: { id: id },
       order: {
         messages: {
-          created_at: 'ASC',
+          createdAt: 'ASC',
         },
       },
     });

--- a/backend/src/chats/chats.service.ts
+++ b/backend/src/chats/chats.service.ts
@@ -128,6 +128,11 @@ export class ChatsService {
     const chat = await this.chatRepository.findOne({
       relations: ['users', 'messages', 'messages.sender'],
       where: { id: id },
+      order: {
+        messages: {
+          created_at: 'ASC',
+        },
+      },
     });
 
     if (!chat) throw new NotFoundException('Chat not found');

--- a/backend/src/core/entities/message.entity.ts
+++ b/backend/src/core/entities/message.entity.ts
@@ -1,4 +1,10 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { ChatEntity, UserEntity } from '.';
 
 @Entity({ name: 'messages' })
@@ -8,6 +14,9 @@ export class MessageEntity {
 
   @Column()
   content: string;
+
+  @CreateDateColumn()
+  created_at: Date;
 
   @ManyToOne(() => ChatEntity, (chat) => chat.messages)
   chat: ChatEntity;

--- a/backend/src/core/entities/message.entity.ts
+++ b/backend/src/core/entities/message.entity.ts
@@ -22,8 +22,7 @@ export class MessageEntity {
   chat: ChatEntity;
 
   @ManyToOne(() => UserEntity, (user) => user.id, {
-    nullable: false,
-    onDelete: 'CASCADE',
+    nullable: true,
   })
   sender: UserEntity;
 

--- a/backend/src/core/entities/message.entity.ts
+++ b/backend/src/core/entities/message.entity.ts
@@ -16,7 +16,7 @@ export class MessageEntity {
   content: string;
 
   @CreateDateColumn()
-  created_at: Date;
+  createdAt: Date;
 
   @ManyToOne(() => ChatEntity, (chat) => chat.messages)
   chat: ChatEntity;

--- a/backend/src/users/status/status.module.ts
+++ b/backend/src/users/status/status.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { StatusGateway } from './status.gateway';
 import { UsersService } from '../users.service';
 import { SessionsService } from '../sessions/sessions.service';
-import { SessionEntity, UserEntity } from '../../core/entities';
+import { MessageEntity, SessionEntity, UserEntity } from '../../core/entities';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { S3ClientProvider } from '../../lib/aws/s3Client';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserEntity, SessionEntity])],
+  imports: [
+    TypeOrmModule.forFeature([UserEntity, SessionEntity, MessageEntity]),
+  ],
   providers: [StatusGateway, UsersService, SessionsService, S3ClientProvider],
   exports: [],
 })

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from './users.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { SessionEntity, UserEntity } from '../core/entities';
+import { MessageEntity, SessionEntity, UserEntity } from '../core/entities';
 import { UsersController } from './users.controller';
 import { Repository } from 'typeorm';
 import { S3ClientProvider } from '../lib/aws/s3Client';
@@ -49,6 +49,12 @@ describe('UsersController', () => {
           provide: getRepositoryToken(SessionEntity),
           useValue: {
             createQueryBuilder: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(MessageEntity),
+          useValue: {
+            update: jest.fn(),
           },
         },
       ],

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -2,11 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
-import { UserEntity, SessionEntity } from '../core/entities';
+import { UserEntity, SessionEntity, MessageEntity } from '../core/entities';
 import { S3ClientProvider } from '../lib/aws/s3Client';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserEntity, SessionEntity])],
+  imports: [
+    TypeOrmModule.forFeature([UserEntity, SessionEntity, MessageEntity]),
+  ],
   controllers: [UsersController],
   providers: [UsersService, S3ClientProvider],
   exports: [UsersService, S3ClientProvider],

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -1,6 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from './users.service';
-import { UserEntity, SessionEntity, AuthProvider } from '../core/entities';
+import {
+  UserEntity,
+  SessionEntity,
+  AuthProvider,
+  MessageEntity,
+} from '../core/entities';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { S3ClientProvider } from '../lib/aws/s3Client';
@@ -47,6 +52,12 @@ describe('UsersService', () => {
           provide: getRepositoryToken(SessionEntity),
           useValue: {
             createQueryBuilder: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(MessageEntity),
+          useValue: {
+            update: jest.fn(),
           },
         },
       ],

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -3,7 +3,12 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { Brackets, DeleteResult, Repository, UpdateResult } from 'typeorm';
 import { CreateUserDto, UpdateUserDto } from './dto';
-import { UserEntity, SessionEntity, AuthProvider } from '../core/entities';
+import {
+  UserEntity,
+  SessionEntity,
+  AuthProvider,
+  MessageEntity,
+} from '../core/entities';
 
 @Injectable()
 export class UsersService {
@@ -12,6 +17,8 @@ export class UsersService {
     private readonly userRepository: Repository<UserEntity>,
     @InjectRepository(SessionEntity)
     private readonly sessionRepository: Repository<SessionEntity>,
+    @InjectRepository(MessageEntity)
+    private readonly messageRepository: Repository<MessageEntity>,
     @Inject(S3Client) private readonly s3Client: S3Client,
   ) {}
 
@@ -42,6 +49,8 @@ export class UsersService {
   }
 
   async deleteUser(id: number): Promise<void> {
+    await this.messageRepository.update({ sender: { id } }, { sender: null });
+
     await Promise.all([
       this.killAllSessionsByUserId(id),
       this.userRepository.delete(id),

--- a/backend/test/integration/chats.spec.ts
+++ b/backend/test/integration/chats.spec.ts
@@ -1,0 +1,83 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmConfigModule } from '../../src/config/typeorm-config.module';
+import { ChatsModule } from '../../src/chats/chats.module';
+import { UsersService } from '../../src/users/users.service';
+import { ChatsService } from '../../src/chats/chats.service';
+import { AuthProvider, ChatAccess, ChatType } from '../../src/core/entities';
+import { UsersModule } from '../../src/users/users.module';
+
+describe('Chats', () => {
+  let app: INestApplication;
+  let usersService: UsersService;
+  let chatsService: ChatsService;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TypeOrmConfigModule, ChatsModule, UsersModule],
+    }).compile();
+    app = moduleFixture.createNestApplication();
+    usersService = app.get(UsersService);
+    chatsService = app.get(ChatsService);
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should be defined', async () => {
+    expect(app).toBeDefined();
+    expect(usersService).toBeDefined();
+    expect(chatsService).toBeDefined();
+  });
+
+  describe('order messages', () => {
+    it('chat direct', async () => {
+      // Arrange
+      const user1 = await usersService.createUser({
+        login: 'user1',
+        provider: AuthProvider.GUEST,
+      });
+      const user2 = await usersService.createUser({
+        login: 'user2',
+        provider: AuthProvider.GUEST,
+      });
+      const chat = await chatsService.create(
+        {
+          userIds: [user1.id, user2.id],
+          access: ChatAccess.PUBLIC,
+          type: ChatType.DIRECT,
+        },
+        user1,
+      );
+      await chatsService.addMessage({
+        content: 'message 1',
+        chatId: chat.id,
+        senderId: user1.id,
+      });
+      await chatsService.addMessage({
+        content: 'message 2',
+        chatId: chat.id,
+        senderId: user2.id,
+      });
+      await chatsService.addMessage({
+        content: 'message 3',
+        chatId: chat.id,
+        senderId: user1.id,
+      });
+      await chatsService.addMessage({
+        content: 'message 4',
+        chatId: chat.id,
+        senderId: user2.id,
+      });
+      // Act
+      const { messages } = await chatsService.findOne(chat.id);
+      // Assert
+      expect(messages[0].content).toEqual('message 1');
+      expect(messages[1].content).toEqual('message 2');
+      expect(messages[2].content).toEqual('message 3');
+      expect(messages[3].content).toEqual('message 4');
+    });
+  });
+});

--- a/frontend/src/routes/Chat.tsx
+++ b/frontend/src/routes/Chat.tsx
@@ -93,7 +93,7 @@ export default function Chat() {
                     }}
                   >
                     <Typography variant="h6">
-                      {message.sender?.nickname}:
+                      {message.sender?.nickname ?? 'deleted user'}:
                     </Typography>
                   </button>
                 </div>


### PR DESCRIPTION
pr dependende dá https://github.com/tenis-de-mesa/ft_transcendence/pull/71
toda vez que um usuário é deletado o campo sender na tabela messages é setado para null