### PR TITLE
Quick Fix: Novo nome do bucket no S3

### DIFF
--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -95,14 +95,14 @@ export class UsersService {
   ): Promise<UpdateResult> {
     const imageKey = user.id + file.originalname;
     const command = new PutObjectCommand({
-      Bucket: 'transcendence-images',
+      Bucket: 'transcendence',
       Key: imageKey,
       Body: file.buffer,
       ContentType: file.mimetype,
     });
     await this.s3Client.send(command);
     return await this.userRepository.update(user.id, {
-      avatarUrl: `https://transcendence-images.s3.amazonaws.com/${imageKey}`,
+      avatarUrl: `https://transcendence.s3.amazonaws.com/${imageKey}`,
     });
   }
 

--- a/backend/test/integration/default-avatar.spec.ts
+++ b/backend/test/integration/default-avatar.spec.ts
@@ -73,7 +73,7 @@ describe('Default Avatar', () => {
     expect(s3ClientMock).toBeCalled();
     expect(imageKey).toEqual(user.id + file.originalname);
     expect(user.avatarUrl).toEqual(
-      `https://transcendence-images.s3.amazonaws.com/${imageKey}`,
+      `https://transcendence.s3.amazonaws.com/${imageKey}`,
     );
   });
 });


### PR DESCRIPTION
Mudei o nome do bucket, esse agora tá na nossa conta compartilhada da AWS

PS: Lembrem de atualizar a `.env` , a que tá pinned no chat tá atualizada

Related to #73 
Parte do secrets manager compartilhado #55 