### PR TITLE
[REFACTOR] Cascade messages and sessions on user deletion

### DIFF
--- a/backend/src/core/entities/message.entity.ts
+++ b/backend/src/core/entities/message.entity.ts
@@ -22,8 +22,8 @@ export class MessageEntity {
   chat: ChatEntity;
 
   @ManyToOne(() => UserEntity, (user) => user.id, {
-    nullable: false,
-    onDelete: 'CASCADE',
+    nullable: true,
+    onDelete: 'SET NULL',
   })
   sender: UserEntity;
 

--- a/backend/src/core/entities/session.entity.ts
+++ b/backend/src/core/entities/session.entity.ts
@@ -28,7 +28,7 @@ export class SessionEntity implements ISession {
   @Column({ nullable: true })
   userId: number;
 
-  @ManyToOne(() => UserEntity, (user) => user.sessions)
+  @ManyToOne(() => UserEntity, (user) => user.sessions, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'userId' })
   user: UserEntity;
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -42,10 +42,7 @@ export class UsersService {
   }
 
   async deleteUser(id: number): Promise<void> {
-    await Promise.all([
-      this.killAllSessionsByUserId(id),
-      this.userRepository.delete(id),
-    ]);
+    await this.userRepository.delete(id);
   }
 
   async killAllSessionsByUserId(


### PR DESCRIPTION
Define _cascade_ nas relações entre usuário/mensagens e usuário/sessões, removendo chamadas de banco extras no `UsersService` e limpando a lógica das entidades.

(Indiretamente corrige um bug onde havia uma infração de _foreign key_ pelo bloco de `Promise.all` chamar as funções de deleção de usuário e de sessão ao mesmo tempo.)