### PR TITLE
[FIX] Add `sortBy` prop to Table component and remove hardcoded `id` sort

### DIFF
--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -19,15 +19,13 @@ import { Typography } from ".";
 export interface TableProps {
   columns: ColumnDef<unknown>[];
   data: unknown[];
+  sortBy?: string;
 }
 
-const Table = ({ columns, data }: TableProps) => {
-  const [sorting, setSorting] = useState<SortingState>([
-    {
-      desc: false,
-      id: "id",
-    },
-  ]);
+const Table = ({ columns, data, sortBy }: TableProps) => {
+  const [sorting, setSorting] = useState<SortingState>(
+    sortBy ? [{ id: sortBy, desc: false }] : []
+  );
 
   const table = useReactTable({
     columns,
@@ -64,7 +62,7 @@ const Table = ({ columns, data }: TableProps) => {
                     >
                       {flexRender(
                         header.column.columnDef.header,
-                        header.getContext(),
+                        header.getContext()
                       )}
                       {header.column.getCanSort() && (
                         <>
@@ -129,7 +127,7 @@ const Pagination = ({ table }: { table: Table<unknown> }) => {
             "flex items-center text-gray-500 dark:text-white hover:text-gray-600 dark:hover:text-gray-200 focus:outline-none",
             {
               "opacity-25": !table.getCanPreviousPage(),
-            },
+            }
           )}
           onClick={() => table.previousPage()}
           disabled={!table.getCanPreviousPage()}
@@ -149,7 +147,7 @@ const Pagination = ({ table }: { table: Table<unknown> }) => {
             "flex items-center text-gray-500 dark:text-white hover:text-gray-600 dark:hover:text-gray-200 focus:outline-none",
             {
               "opacity-25": !table.getCanNextPage(),
-            },
+            }
           )}
           onClick={() => table.nextPage()}
           disabled={!table.getCanNextPage()}

--- a/frontend/src/routes/Channels/index.tsx
+++ b/frontend/src/routes/Channels/index.tsx
@@ -108,6 +108,7 @@ export default function Channels() {
         <Table
           columns={columns as unknown as ColumnDef<Data>[]}
           data={channels as unknown as Data[]}
+          sortBy="id"
         />
       </div>
     </>


### PR DESCRIPTION
Resolve isso aqui:
![image](https://github.com/tenis-de-mesa/ft_transcendence/assets/31555284/7aad7f9b-c81c-4259-a37c-1f20b96aca5c)
