### PR TITLE
[FIX] Properly show error when accessing non existent/not member chats

### DIFF
--- a/backend/src/auth/guards/channel-member.guard.ts
+++ b/backend/src/auth/guards/channel-member.guard.ts
@@ -1,0 +1,37 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ChatMemberEntity } from '../../core/entities';
+
+@Injectable()
+export class ChannelMemberGuard implements CanActivate {
+  constructor(
+    @InjectRepository(ChatMemberEntity)
+    private readonly chatMemberRepository: Repository<ChatMemberEntity>,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const userId = request.user?.id;
+    const chatId = request.params?.id;
+
+    if (!userId || !chatId) {
+      throw new UnauthorizedException('Member or chat not found');
+    }
+
+    const member = await this.chatMemberRepository.findOne({
+      where: { chatId, userId },
+    });
+
+    if (!member) {
+      throw new UnauthorizedException('User is not a member of this chat');
+    }
+
+    return true;
+  }
+}

--- a/backend/src/auth/guards/index.ts
+++ b/backend/src/auth/guards/index.ts
@@ -4,3 +4,4 @@ export * from './guest.guard';
 export * from './tfa-disabled.guard';
 export * from './tfa-enabled.guard';
 export * from './channel-role.guard';
+export * from './channel-member.guard';

--- a/backend/src/chats/chats.controller.ts
+++ b/backend/src/chats/chats.controller.ts
@@ -14,7 +14,11 @@ import {
 } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ChatsService } from './chats.service';
-import { AuthenticatedGuard, ChannelRoleGuard } from '../auth/guards';
+import {
+  AuthenticatedGuard,
+  ChannelMemberGuard,
+  ChannelRoleGuard,
+} from '../auth/guards';
 import { ChannelRoles, User } from '../core/decorators';
 import {
   ChatEntity,
@@ -112,6 +116,7 @@ export class ChatsController {
   }
 
   @Get(':id')
+  @UseGuards(ChannelMemberGuard)
   async show(@Param('id', ParseIntPipe) id: number): Promise<ChatEntity> {
     return await this.chatsService.findOne(id);
   }
@@ -126,6 +131,7 @@ export class ChatsController {
   }
 
   @Post(':id/leave')
+  @UseGuards(ChannelMemberGuard)
   async leaveChat(
     @Param('id', ParseIntPipe) chatId: number,
     @User('id') userId: number,
@@ -135,6 +141,7 @@ export class ChatsController {
   }
 
   @Get(':id/role')
+  @UseGuards(ChannelMemberGuard)
   async getMemberRole(
     @Param('id', ParseIntPipe) id: number,
     @User('id') userId: number,
@@ -245,6 +252,7 @@ export class ChatsController {
   }
 
   @Get(':id/members')
+  @UseGuards(ChannelMemberGuard)
   async getMembers(
     @Param('id', ParseIntPipe) id: number,
   ): Promise<ChatMemberEntity[]> {

--- a/frontend/src/loaders/loadChat.ts
+++ b/frontend/src/loaders/loadChat.ts
@@ -1,7 +1,25 @@
 import { LoaderFunctionArgs } from "react-router-dom";
+import { makeRequest } from "../api";
+import { Chat } from "../types";
 
 export async function loadChat({ params }: LoaderFunctionArgs) {
-  return fetch(`http://localhost:3001/chats/${params.id}`, {
-    credentials: "include",
+  const { data, error } = await makeRequest<Chat>(`/chats/${params.id}`, {
+    method: "GET",
   });
+
+  if (error) {
+    if (error.statusCode === 401) {
+      throw new Response("Not Found", {
+        status: 404,
+        statusText: "Not Found",
+      });
+    }
+
+    throw new Response(error.message, {
+      status: error.statusCode,
+      statusText: error.message,
+    });
+  }
+
+  return data;
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -159,6 +159,7 @@ const router = createBrowserRouter(
           </Route>
         </Route>
       </Route>
+      <Route path="*" element={<ErrorBoundary />} />
     </Route>,
   ),
 );

--- a/frontend/src/routes/ErrorBoundary.tsx
+++ b/frontend/src/routes/ErrorBoundary.tsx
@@ -1,16 +1,29 @@
-import { Link, useRouteError } from "react-router-dom";
+import { Link, isRouteErrorResponse, useRouteError } from "react-router-dom";
 import { Button } from "../components/Button";
 import { Typography } from "../components/Typography";
 import classNames from "classnames";
 import { isDark } from "./Root";
 
 export default function ErrorBoundary() {
-  const error: Response = useRouteError() as Response;
+  const error = useRouteError();
 
+  // FIXME: Remove this log
   console.error("ErrorBoundary: ", error);
 
-  const status = error?.status ?? "?";
-  const statusText = error?.statusText ?? "Internal Error";
+  let status = 500;
+  let statusText: string;
+
+  if (isRouteErrorResponse(error)) {
+    status = error.status;
+    statusText = error.statusText;
+  } else if (error instanceof Error) {
+    statusText = error.message;
+  } else if (typeof error === "string") {
+    statusText = error;
+  } else {
+    status = 404;
+    statusText = "Not Found";
+  }
 
   return (
     <>
@@ -19,16 +32,11 @@ export default function ErrorBoundary() {
           dark: isDark,
         })}
       >
-        <div className="grid h-screen place-content-center text-center bg-gray-300 dark:bg-gray-700">
-          <Typography customWeight="regular" variant="h1">
-            {status}
-          </Typography>
-          <Typography customWeight="regular" variant="h4">
-            {statusText}
-          </Typography>
-          <br></br>
-          <Link to={"/"} className="flex justify-center">
-            <Button size="md" variant="info">
+        <div className="grid h-screen place-content-center text-center space-y-2 bg-gray-300 dark:bg-gray-700">
+          <Typography variant="h1">{status}</Typography>
+          <Typography variant="h4">{statusText}</Typography>
+          <Link to="/" className="flex">
+            <Button size="md" variant="info" className="w-full justify-center">
               Home
             </Button>
           </Link>


### PR DESCRIPTION
Correção para o problema de usuários conseguirem acessar chats dos quais eles não são membros ou que não existem. O tratamento é feito usando o `errorElement`, onde temos um componente `ErrorBoundary` que trata erros vindos de actions e loaders. Por mais que esse elemento já existisse antes, ele só trata o erro se o loader der `throw` numa exceção e, por padrão, o `fetch` não joga exceções. Sendo assim, eu usei a função de abstração da API `makeRequest` e joguei uma exceção manualmente em caso de erro. 
Por ora, é uma mudança que só foi feita para os chats, mas pretendo abrir uma nova PR corrigindo todos os loaders pra que joguem exceções em caso de falha.
Uma guarda foi adicionada no backend pra restringir o acesso a chats para usuários que não são membros.
Também foi adicionada uma rota no front com o `path="*"` para capturar todos os acessos a rotas não existentes, exibindo uma tela de 404 Not Found.

Resolve #167.