### PR TITLE
[FIX] Properly update database user when recovery codes are regenerated

### DIFF
--- a/backend/src/auth/tfa/tfa.controller.ts
+++ b/backend/src/auth/tfa/tfa.controller.ts
@@ -108,8 +108,6 @@ export class TfaController {
       throw new UnauthorizedException('Invalid two factor authentication code');
     }
 
-    const { plain } = await this.tfaService.tfaGenerateRecoveryCodes();
-
-    return plain;
+    return await this.tfaService.tfaEnable(user);
   }
 }

--- a/backend/src/auth/tfa/tfa.service.ts
+++ b/backend/src/auth/tfa/tfa.service.ts
@@ -47,14 +47,14 @@ export class TfaService {
   }
 
   async tfaEnable(user: UserEntity): Promise<string[]> {
-    const recoveryCodes = await this.tfaGenerateRecoveryCodes();
+    const { plain, hashed } = await this.tfaGenerateRecoveryCodes();
 
     await this.usersService.updateUser(user.id, {
       tfaEnabled: true,
-      tfaRecoveryCodes: recoveryCodes.hashed,
+      tfaRecoveryCodes: hashed,
     });
 
-    return recoveryCodes.plain;
+    return plain;
   }
 
   async tfaDisable(user: UserEntity): Promise<void> {


### PR DESCRIPTION
Atualmente, os códigos regerados pela rota `/tfa/regenerate-recovery-codes` não são atualizados no banco de dados. Essa PR corrige esse comportamento.