### PR TITLE
[FIX] Properly redirect to chat when accessing `/chats/new`

### DIFF
--- a/frontend/src/loaders/index.ts
+++ b/frontend/src/loaders/index.ts
@@ -10,3 +10,4 @@ export * from "./loadAllChats";
 export * from "./generateTFASecret";
 export * from "./loadGame";
 export * from "./loadGames";
+export * from "./loadNewChat";

--- a/frontend/src/loaders/loadNewChat.ts
+++ b/frontend/src/loaders/loadNewChat.ts
@@ -1,0 +1,18 @@
+import { LoaderFunctionArgs, redirect } from "react-router-dom";
+import { makeRequest } from "../api";
+import { Chat } from "../types";
+import { loadUserById } from ".";
+
+export async function loadNewChat({ request, params }: LoaderFunctionArgs) {
+  const { userId } = params;
+
+  const { data, error } = await makeRequest<Chat>(`/chats/with/${userId}`, {
+    method: "GET",
+  });
+
+  if (!error) {
+    return redirect(`/chats/${data.id}`);
+  }
+
+  return loadUserById({ request, params });
+}

--- a/frontend/src/loaders/loadUserById.ts
+++ b/frontend/src/loaders/loadUserById.ts
@@ -3,7 +3,9 @@ import { makeRequest } from "../api";
 import { User } from "../types";
 
 export async function loadUserById({ params }: LoaderFunctionArgs) {
-  const { data, error } = await makeRequest<User>(`/users/${params.id}`, {
+  const { userId } = params;
+
+  const { data, error } = await makeRequest<User>(`/users/${userId}`, {
     method: "GET",
   });
 

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -17,6 +17,7 @@ import {
   generateTFASecret,
   loadGame,
   loadGames,
+  loadNewChat,
 } from "./loaders";
 
 import {
@@ -111,7 +112,11 @@ const router = createBrowserRouter(
             action={createChat}
           >
             <Route path="with/:userId" loader={redirectToChat} />
-            <Route path="new/:id" element={<ChatNew />} loader={loadUserById} />
+            <Route
+              path="new/:userId"
+              element={<ChatNew />}
+              loader={loadNewChat}
+            />
             <Route
               path=":id"
               element={<Chat />}
@@ -167,8 +172,8 @@ const router = createBrowserRouter(
         </Route>
       </Route>
       <Route path="*" element={<ErrorBoundary />} />
-    </Route>,
-  ),
+    </Route>
+  )
 );
 
 export default router;


### PR DESCRIPTION
Novo loader que verifica se o chat já existe. Se sim, redireciona pro chat, se não, chama o loader `loadUserById` igual já fazia antigamente.

Resolve #185.